### PR TITLE
Fix redirect query string param name

### DIFF
--- a/box/client.py
+++ b/box/client.py
@@ -113,7 +113,7 @@ def start_authenticate_v2(client_id, state=None, redirect_uri=None):
         args['state'] = state
 
     if redirect_uri:
-        args['redirect_url'] = redirect_uri
+        args['redirect_uri'] = redirect_uri
 
     return 'https://www.box.com/api/oauth2/authorize?' + urlencode(args)
 

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -181,7 +181,7 @@ class TestAuthenticationV2(unittest.TestCase):
         self.assertDictEqual({
             'response_type': ['code'],
             'client_id': ['1111'],
-            'redirect_url': ['https://foo.org?a=b']
+            'redirect_uri': ['https://foo.org?a=b']
         }, query)
 
     def test_oauth2_token_request(self):


### PR DESCRIPTION
Box expects the parameter to be named redirect_uri not redirect_url.  This causes an Error: redirect_uri_missing.
