### PR TITLE
upload_file method did not consider the provided file name

### DIFF
--- a/box/client.py
+++ b/box/client.py
@@ -559,7 +559,7 @@ class BoxClient(object):
         response = requests.post('https://upload.box.com/api/2.0/files/content',
                                  form,
                                  headers=self.default_headers,
-                                 files={filename: fileobj})
+                                 files={filename: (filename, fileobj)})
 
         self._check_for_errors(response)
         return response.json()['entries'][0]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -415,7 +415,7 @@ class TestClient(unittest.TestCase):
             .with_args('https://upload.box.com/api/2.0/files/content',
                        {'parent_id': '666'},
                        headers=client.default_headers,
-                       files={'hello.jpg': FileObjMatcher('hello world')})
+                       files={'hello.jpg': ('hello.jpg', FileObjMatcher('hello world'))})
             .and_return(response)
             .once())
 
@@ -438,7 +438,7 @@ class TestClient(unittest.TestCase):
                            'content_created_at': '2006-05-04T03:02:01+00:00'
                        },
                        headers=client.default_headers,
-                       files={'hello.jpg': FileObjMatcher('hello world')})
+                       files={'hello.jpg': ('hello.jpg', FileObjMatcher('hello world'))})
             .and_return(response)
             .once())
 
@@ -459,7 +459,7 @@ class TestClient(unittest.TestCase):
             .with_args('https://upload.box.com/api/2.0/files/content',
                        {'parent_id': '666'},
                        headers=client.default_headers,
-                       files={'hello.jpg': FileObjMatcher('hello world')})
+                       files={'hello.jpg': ('hello.jpg', FileObjMatcher('hello world'))})
             .and_return(response)
             .once())
 


### PR DESCRIPTION
The call client.upload_file('hello.txt', open('/path/to/file/test.txt‘,'rb')) resulted in the file test.txt on box.com.

The multipart message in the post request looked like the following:

--22f4070af4404a26b26e8af463325ac1
Content-Disposition: form-data; name="hello.txt"; filename="test.txt"
....
--22f4070af4404a26b26e8af463325ac1--

This could be fixed by changing the files parameter on requests.post to "files={filename: (filename, fileobj)}".
