### PR TITLE
Support for copying folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ metadata = client.copy_file('123456', new_filename='goodbye.txt')
 ```
 
 
+Copying a folder
+--------------
+```python
+metadata = client.copy_folder('361015', destination_parent='510163', new_foldername='goodbye')
+>>> metadata['id']
+'149148'
+```
+
+
 Receiving & waiting for events
 ------------------------------
 ```python
@@ -88,7 +97,7 @@ url = start_authenticate_v2('my_api_key')
 'https://www.box.com/api/oauth2/authorize?response_type=code&client_id=my_api_key'
 ```
 
-Next, redirect the user to url.  
+Next, redirect the user to url.
 Once he accepts, a redirect will be issued to the page defined in your developer settings. The "code" is passed as a GET argument.
 
 ```python
@@ -107,8 +116,8 @@ client = BoxClient(response['access_token'])
 ```
 
 ### Token refresh
-The v2 security API introduces a mandatory token refresh mechanism (according to Box, this was done to mitigate the impact of token theft).  
-Essentially, every so often, the token needs to be "refreshed", which involves hitting a Box endpoint with a special "refresh token", which returns new access  & refresh tokens that replace the old ones.  
+The v2 security API introduces a mandatory token refresh mechanism (according to Box, this was done to mitigate the impact of token theft).
+Essentially, every so often, the token needs to be "refreshed", which involves hitting a Box endpoint with a special "refresh token", which returns new access  & refresh tokens that replace the old ones.
 For more details, see here: http://developers.box.com/oauth/
 
 

--- a/box/client.py
+++ b/box/client.py
@@ -422,6 +422,33 @@ class BoxClient(object):
             offset += batch_size
             content = self.get_folder_content(folder_id, limit=batch_size, offset=offset)
 
+    def copy_folder(self, folder_id, destination_parent, new_foldername=None):
+        """
+        Copies a given `folder_id` into a new location, `destination_parent`. By default
+        the original name of the folder is used unless `new_foldername` is provided.
+
+        @see https://developers.box.com/docs/#folders-copy-a-folder
+
+        Args:
+            - file_id: the id of the file we want to copy
+            - destination_parent: ID or a dictionary (as returned by the apis) of the target folder
+            - new_foldername: (optional) name the copy `new_foldername`, if provided.
+
+        Returns:
+            - a dictionary containing the metadata of newly created copy
+        """
+
+        data = {
+          'parent': {
+            'id': self._get_id(destination_parent)
+          }
+        }
+
+        if new_foldername:
+            data.update({'name': new_foldername})
+
+        return self._request('post', 'folders/{0}/copy'.format(folder_id), data=data).json()
+
     def create_folder(self, name, parent=0):
         """
         creates a new folder under the parent.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,6 +254,15 @@ class TestClient(unittest.TestCase):
         client = self.make_client("get", 'folders/123/collaborations', result={'a': 'b'})
         self.assertEqual({'a': 'b'}, client.get_folder_collaborations(123))
 
+    def test_copy_folder(self):
+        client = self.make_client("post", 'folders/123/copy', data={'parent': {'id': '666'}}, result={'id': '1'})
+        result = client.copy_folder(123, 666)
+        self.assertEqual({'id': '1'}, result)
+
+        client = self.make_client("post", 'folders/123/copy', data={'parent': {'id': '666'}, 'name': 'goatse.cx'}, result={'id': '1'})
+        result = client.copy_folder(123, 666, 'goatse.cx')
+        self.assertEqual({'id': '1'}, result)
+
     def test_create_folder_no_parent(self):
         expected_dict = {
             'name': 'hello',


### PR DESCRIPTION
Client support for `copy_folder` and related tests.

https://developers.box.com/docs/#folders-copy-a-folder

``` bash
running build_ext
test_finish_authenticate_error (tests.test_authentication.TestAuthenticationV1) ... ok
test_finish_authenticate_v1 (tests.test_authentication.TestAuthenticationV1) ... ok
test_refresh (tests.test_authentication.TestAuthenticationV1) ... ok
test_start_authenticate_v1 (tests.test_authentication.TestAuthenticationV1) ... ok
test_start_authenticate_v1_fail (tests.test_authentication.TestAuthenticationV1) ... ok
test_finish_authenticate_v2 (tests.test_authentication.TestAuthenticationV2) ... ok
test_handle_auth_response (tests.test_authentication.TestAuthenticationV2) ... ok
test_oauth2_token_request (tests.test_authentication.TestAuthenticationV2) ... ok
test_oauth2_token_request_error (tests.test_authentication.TestAuthenticationV2) ... ok
test_refresh (tests.test_authentication.TestAuthenticationV2) ... ok
test_refresh_v2_token (tests.test_authentication.TestAuthenticationV2) ... ok
test_start_authenticate_v2 (tests.test_authentication.TestAuthenticationV2) ... ok
test_credentials_v1 (tests.test_authentication.TestCredentials) ... ok
test_credentials_v2 (tests.test_authentication.TestCredentials) ... ok
test_add_assignment (tests.test_client.TestClient) ... ok
test_add_comment_to_comment (tests.test_client.TestClient) ... ok
test_add_comment_to_file (tests.test_client.TestClient) ... ok
test_add_task (tests.test_client.TestClient) ... ok
test_automatic_refresh (tests.test_client.TestClient) ... ok
test_change_comment (tests.test_client.TestClient) ... ok
test_change_task (tests.test_client.TestClient) ... ok
test_copy_file (tests.test_client.TestClient) ... ok
test_copy_folder (tests.test_client.TestClient) ... ok
test_create_collaboration_by_login (tests.test_client.TestClient) ... ok
test_create_collaboration_by_user_id (tests.test_client.TestClient) ... ok
test_create_folder_no_parent (tests.test_client.TestClient) ... ok
test_create_folder_with_parent (tests.test_client.TestClient) ... ok
test_delete (tests.test_client.TestClient) ... ok
test_delete_assignment (tests.test_client.TestClient) ... ok
test_delete_collaboration (tests.test_client.TestClient) ... ok
test_delete_comment (tests.test_client.TestClient) ... ok
test_delete_file (tests.test_client.TestClient) ... ok
test_delete_folder (tests.test_client.TestClient) ... ok
test_delete_no_headers (tests.test_client.TestClient) ... ok
test_delete_task (tests.test_client.TestClient) ... ok
test_delete_trashed_file (tests.test_client.TestClient) ... ok
test_download_file (tests.test_client.TestClient) ... ok
test_download_file_with_version (tests.test_client.TestClient) ... ok
test_edit_collaboration (tests.test_client.TestClient) ... ok
test_file_get_comments (tests.test_client.TestClient) ... ok
test_file_get_tasks (tests.test_client.TestClient) ... ok
test_get (tests.test_client.TestClient) ... ok
test_get_assignment_information (tests.test_client.TestClient) ... ok
test_get_client_with_retry (tests.test_client.TestClient) ... ok
test_get_collaboration (tests.test_client.TestClient) ... ok
test_get_comment_information (tests.test_client.TestClient) ... ok
test_get_events (tests.test_client.TestClient) ... ok
test_get_file_metadata (tests.test_client.TestClient) ... ok
test_get_folder (tests.test_client.TestClient) ... ok
test_get_folder_collaborations (tests.test_client.TestClient) ... ok
test_get_folder_content (tests.test_client.TestClient) ... ok
test_get_folder_iterator (tests.test_client.TestClient) ... ok
test_get_folder_iterator_zero_content (tests.test_client.TestClient) ... ok
test_get_id (tests.test_client.TestClient) ... ok
test_get_long_poll_data (tests.test_client.TestClient) ... ok
test_get_path_of_file (tests.test_client.TestClient) ... ok
test_get_task_assignments (tests.test_client.TestClient) ... ok
test_get_task_information (tests.test_client.TestClient) ... ok
test_get_thumbnail (tests.test_client.TestClient) ... ok
test_get_thumbnail_with_params (tests.test_client.TestClient) ... ok
test_get_user_info (tests.test_client.TestClient) ... ok
test_get_user_list (tests.test_client.TestClient) ... ok
test_handle_error (tests.test_client.TestClient) ... ok
test_init_with_credentials_class (tests.test_client.TestClient) ... ok
test_init_with_string (tests.test_client.TestClient) ... ok
test_long_poll_for_events_and_errors (tests.test_client.TestClient) ... ok
test_long_poll_for_events_multiple_tries (tests.test_client.TestClient) ... ok
test_long_poll_for_events_ok (tests.test_client.TestClient) ... ok
test_long_poll_for_latest_events (tests.test_client.TestClient) ... ok
test_overwrite_file (tests.test_client.TestClient) ... ok
test_post_data (tests.test_client.TestClient) ... ok
test_post_dict (tests.test_client.TestClient) ... ok
test_put_data (tests.test_client.TestClient) ... ok
test_put_dict (tests.test_client.TestClient) ... ok
test_search (tests.test_client.TestClient) ... ok
test_share_link (tests.test_client.TestClient) ... ok
test_update_assignment (tests.test_client.TestClient) ... ok
test_upload_file (tests.test_client.TestClient) ... ok
test_upload_file_with_parent_as_dict (tests.test_client.TestClient) ... ok
test_upload_file_with_timestamps (tests.test_client.TestClient) ... ok
test_matcher_eq_works (tests.test_utils.TestFileObjMatcher) ... ok
test_rollback_to_stream (tests.test_utils.TestFileObjMatcher) ... ok

----------------------------------------------------------------------
Ran 82 tests in 1.077s

OK
```
