### PR TITLE
Refresh tokens while uploading files to box

### DIFF
--- a/box/client.py
+++ b/box/client.py
@@ -617,7 +617,7 @@ class BoxClient(object):
             - content_modified_at: (optional) a timestamp (datetime or a properly formatted string) of the time the
               content was last modified
         """
-
+        try_refresh=True
         form = {"parent_id": self._get_id(parent)}
 
         if content_created_at:
@@ -631,7 +631,9 @@ class BoxClient(object):
                                  form,
                                  headers=self.default_headers,
                                  files={filename: (filename, fileobj)})
-
+        if response.status_code == UNAUTHORIZED and try_refresh and self.credentials.refresh():
+            try_refresh=False
+            return self.upload_file(filename, fileobj)
         self._check_for_errors(response)
         return response.json()['entries'][0]
 


### PR DESCRIPTION
The code did not check that the access token was valid while uploading a file to box. This patch refreshes the token and then uploads the file.
