### PR TITLE
Add a little HTTP request resilience

### DIFF
--- a/box/client.py
+++ b/box/client.py
@@ -14,7 +14,8 @@ import requests
 
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Timeout
-
+from requests.packages.urllib3.poolmanager import PoolManager
+import ssl
 
 class EventFilter(object):
     """
@@ -292,6 +293,12 @@ class BoxHTTPAdapter(HTTPAdapter):
         self.timeout = Timeout(**timeout_kwargs)
 
         super(BoxHTTPAdapter, self).__init__(*args, **kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = PoolManager(num_pools=connections,
+                                       maxsize=maxsize,
+                                       block=block,
+                                       ssl_version=ssl.PROTOCOL_TLSv1)
 
     def send(self, *args, **kwargs):
         kwargs.setdefault('timeout', self.timeout)

--- a/box/client.py
+++ b/box/client.py
@@ -270,8 +270,10 @@ class CredentialsV2(object):
 
 
 class BoxHTTPAdapter(HTTPAdapter):
-    # noting that read timeout covers possible upload time
     def __init__(self, *args, **kwargs):
+        # pull out and transform Timeout parameters from kwargs;
+        # values for read and connect timeouts are set by default
+        # and may be disabled by passing 'None'
         timeout_kwargs = {}
         if 'read_timeout' in kwargs:
             read_timeout = kwargs.pop('read_timeout')
@@ -287,7 +289,6 @@ class BoxHTTPAdapter(HTTPAdapter):
         else:
             timeout_kwargs['connect'] = 2.0
 
-        # todo: need to permit default values somewhow
         self.timeout = Timeout(**timeout_kwargs)
 
         super(BoxHTTPAdapter, self).__init__(*args, **kwargs)
@@ -303,7 +304,7 @@ class BoxClient(object):
         """
         Args:
             - credentials: an access_token string, or an instance of CredentialsV1/CredentialsV2
-            - requests_session: a custom requests session object, optioanl
+            - requests_session: a custom requests session object, optional
         """
         if requests_session is None:
             self.session = requests.Session()


### PR DESCRIPTION
At times (more often than I would like) box.com API services [experience connectivity issues](http://status.box.com). (And at times a pesky OS X 10.9 [network stack bug](https://discussions.apple.com/thread/5551686) gets in the way.) The occasional symptoms are hung sockets and SSL EOL/EOF errors.

I worked-in a requests session HTTP adapter that puts timeout values of requests and retries requests that fail.

With some massaging, could this mechanism be part of box.py?
